### PR TITLE
Add pytest checks for HTML metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# EpiSafe Static Site
+
+This repository contains the static HTML files for the EpiSafe website.
+
+## Running Tests
+
+Python tests are located in the `tests/` directory and require `pytest` and
+`beautifulsoup4` to be installed. Install the dependencies and run `pytest`:
+
+```bash
+pip install pytest beautifulsoup4
+pytest
+```
+

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,24 @@
+import pytest
+from bs4 import BeautifulSoup
+from pathlib import Path
+
+
+def html_files():
+    root = Path(__file__).resolve().parents[1]
+    return list(root.glob('*.html'))
+
+
+def pytest_generate_tests(metafunc):
+    if 'html_file' in metafunc.fixturenames:
+        metafunc.parametrize('html_file', html_files())
+
+
+def test_title_and_favicon(html_file):
+    content = Path(html_file).read_text(encoding='utf-8')
+    soup = BeautifulSoup(content, 'html.parser')
+
+    title = soup.find('title')
+    assert title is not None, f'{html_file} missing <title>'
+
+    icon_link = soup.find('link', rel='icon')
+    assert icon_link is not None and icon_link.get('href'), f'{html_file} missing favicon link'

--- a/thankyou.html
+++ b/thankyou.html
@@ -1,10 +1,11 @@
-﻿<!-- thankyou.html -->
+<!-- thankyou.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Thank You | EpiSafe™</title>
+  <link rel="icon" href="episafeavicon.ico" type="image/x-icon" />
   <style>
     body {
       background-color: #000;


### PR DESCRIPTION
## Summary
- add README with instructions for running tests
- add test using pytest and BeautifulSoup to verify HTML metadata
- include favicon link in `thankyou.html`

## Testing
- `pytest -q` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685771adb59083219f37a72feaf8ed36