### PR TITLE
Fix achievements page home link and image styling

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Achievements | EpiSafe</title>
-  <link rel="icon" href="episafeavicon.ico" type="image/x-icon" />
+  <link rel="icon" href="images/episafeavicon.ico" type="image/x-icon" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
     * {
@@ -87,6 +87,7 @@
       width: 100%;
       border-radius: 12px;
       margin-bottom: 1rem;
+      box-shadow: 0 0 15px rgba(255, 165, 0, 0.5);
     }
     .achievement h2 {
       color: #FFA500;
@@ -102,7 +103,7 @@
     }
     @media (min-width: 768px) {
       .achievement img {
-        width: 300px;
+        width: 500px;
       }
     }
   </style>
@@ -130,7 +131,7 @@
 <body>
   <header>
     <div class="logo">
-      <img src="episafelogoog.png" alt="EpiSafe Icon" />
+      <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
     </div>
     <nav>
       <a href="index.html">Home</a>


### PR DESCRIPTION
## Summary
- make achievements favicon path consistent
- link the logo to the homepage
- enlarge the achievements photo with a glow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685782798ecc8321b2985d87bb0a06db