### PR TITLE
Add dark mode toggle

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -29,9 +29,35 @@
       color: inherit;
       text-decoration: none;
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
   </style>
 </head>
 <body>
+  <button id="theme-toggle">Toggle Theme</button>
   <h1>Accessibility Statement</h1>
   <p>We strive to make our website accessible to everyone. If you encounter an issue, please contact us so we can address it.</p>
 
@@ -39,5 +65,21 @@
     <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
+  });
+</script>
 </body>
 </html>

--- a/achievements.html
+++ b/achievements.html
@@ -68,6 +68,31 @@
       text-decoration: none;
       font-weight: bold;
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
     .achievement {
       background-color: #fff;
       padding: 2rem;
@@ -136,6 +161,18 @@
           });
         }
       });
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
     });
   </script>
 </head>
@@ -147,6 +184,7 @@
     <nav>
       <a href="index.html">Home</a>
     </nav>
+    <button id="theme-toggle">Toggle Theme</button>
   </header>
 
   <div class="achievements-container">

--- a/index.html
+++ b/index.html
@@ -72,6 +72,31 @@
     nav a:active {
       transform: scale(0.95);
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
     .hero {
       display: flex;
       flex-direction: column;
@@ -256,6 +281,18 @@
           });
         }
       });
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
     });
   </script>
 </head>
@@ -268,6 +305,7 @@
     <a href="team.html">Meet the Team</a>
     <a href="achievements.html">Achievements</a>
   </nav>
+  <button id="theme-toggle">Toggle Theme</button>
 </header>
 
   <section class="hero">

--- a/privacy.html
+++ b/privacy.html
@@ -29,9 +29,35 @@
       color: inherit;
       text-decoration: none;
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
   </style>
 </head>
 <body>
+  <button id="theme-toggle">Toggle Theme</button>
   <h1>Privacy Policy</h1>
   <p>Your privacy is important to us. This page outlines how we handle your personal information. Since this is a demo site, no data is collected or stored.</p>
 
@@ -39,5 +65,21 @@
     <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
+  });
+</script>
 </body>
 </html>

--- a/team.html
+++ b/team.html
@@ -88,6 +88,31 @@
     .back-button a:active {
       transform: scale(0.95);
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
     .member {
       background-color: #fff;
       padding: 2rem;
@@ -160,6 +185,18 @@
           });
         }
       });
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
     });
   </script>
 </head>
@@ -171,6 +208,7 @@
     <nav>
       <a href="index.html">Home</a>
     </nav>
+    <button id="theme-toggle">Toggle Theme</button>
   </header>
 
   <div class="team-container">

--- a/terms.html
+++ b/terms.html
@@ -29,9 +29,35 @@
       color: inherit;
       text-decoration: none;
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
   </style>
 </head>
 <body>
+  <button id="theme-toggle">Toggle Theme</button>
   <h1>Terms &amp; Conditions</h1>
   <p>This website is provided for demonstration purposes only. All content is fictitious and should not be considered legal advice.</p>
 
@@ -39,5 +65,21 @@
     <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
+  });
+</script>
 </body>
 </html>

--- a/thankyou.html
+++ b/thankyou.html
@@ -40,9 +40,35 @@
       color: inherit;
       text-decoration: none;
     }
+      #theme-toggle {
+        margin-left: 1rem;
+        background: none;
+        border: 2px solid currentColor;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      html.dark-mode body {
+        background-color: #121212;
+        color: #fff;
+      }
+      html.dark-mode header {
+        background: linear-gradient(to right, #333, #555);
+      }
+      html.dark-mode .product-card {
+        background: #1e1e1e;
+      }
+      html.dark-mode .footer {
+        background-color: #333;
+        color: #fff;
+      }
+      html.dark-mode a {
+        color: #FFA500;
+      }
   </style>
 </head>
 <body>
+  <button id="theme-toggle">Toggle Theme</button>
   <h1>Thank You!</h1>
   <p>Your message has been sent successfully. We'll be in touch soon.</p>
   <a href="/">Back to Homepage</a>
@@ -51,5 +77,21 @@
     <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark-mode');
+        const isDark = document.documentElement.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a toggle button on every page to switch between light and dark modes
- apply basic dark-mode styles
- remember mode choice using localStorage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685785ebcf04832192c5f600951258b6