### PR TITLE
Remove dark mode toggle and unify footer styling

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -61,35 +61,12 @@
       text-decoration: none;
       margin: 0 0.5rem;
     }
-    html.dark-mode body {
-      background-color: #121212;
-      color: #fff;
-    }
-    html.dark-mode header {
-      background: linear-gradient(to right, #333, #555);
-    }
-    html.dark-mode .footer {
-      background-color: #333;
-    }
-    html.dark-mode a {
-      color: #FFA500;
-    }
-    #theme-toggle {
-      background-color: #FFA500;
-      color: #000;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 6px;
-      font-weight: bold;
-      cursor: pointer;
-      margin-bottom: 1rem;
-    }
+
   </style>
 </head>
 <body>
   <div class="back-button">
     <a href="index.html">← Back to Home</a>
-  <button id="theme-toggle">Toggle Theme</button>
   <div class="back-button">
     <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon"> Back to Home</a>
   </div>
@@ -104,21 +81,7 @@
     </p>
   </div>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'dark') {
-        document.documentElement.classList.add('dark-mode');
-      }
-
-      const toggleBtn = document.getElementById('theme-toggle');
-      if (toggleBtn) {
-        toggleBtn.addEventListener('click', () => {
-          document.documentElement.classList.toggle('dark-mode');
-          const isDark = document.documentElement.classList.contains('dark-mode');
-          localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        });
-      }
-    });
+    // Theme toggling removed
   </script>
 </body>
 </html>

--- a/achievements.html
+++ b/achievements.html
@@ -68,31 +68,6 @@
       text-decoration: none;
       font-weight: bold;
     }
-      #theme-toggle {
-        margin-left: 1rem;
-        background: none;
-        border: 2px solid currentColor;
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      html.dark-mode body {
-        background-color: #121212;
-        color: #fff;
-      }
-      html.dark-mode header {
-        background: linear-gradient(to right, #333, #555);
-      }
-      html.dark-mode .product-card {
-        background: #1e1e1e;
-      }
-      html.dark-mode .footer {
-        background-color: #333;
-        color: #fff;
-      }
-      html.dark-mode a {
-        color: #FFA500;
-      }
     .achievement {
       background-color: #111;
       padding: 2rem;
@@ -134,7 +109,7 @@
       font-size: 0.8rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
     }
     @media (min-width: 768px) {
@@ -161,18 +136,7 @@
           });
         }
       });
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
-    }
-    const toggleBtn = document.getElementById('theme-toggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark-mode');
-        const isDark = document.documentElement.classList.contains('dark-mode');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    }
+    // Theme toggling removed
     });
   </script>
 </head>
@@ -184,7 +148,6 @@
     <nav>
       <a href="index.html">Home</a>
     </nav>
-    <button id="theme-toggle">Toggle Theme</button>
   </header>
 
   <div class="achievements-container">

--- a/index.html
+++ b/index.html
@@ -72,31 +72,7 @@
     nav a:active {
       transform: scale(0.95);
     }
-      #theme-toggle {
-        margin-left: 1rem;
-        background: none;
-        border: 2px solid currentColor;
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      html.dark-mode body {
-        background-color: #121212;
-        color: #fff;
-      }
-      html.dark-mode header {
-        background: linear-gradient(to right, #333, #555);
-      }
-      html.dark-mode .product-card {
-        background: #1e1e1e;
-      }
-      html.dark-mode .footer {
-        background-color: #333;
-        color: #fff;
-      }
-      html.dark-mode a {
-        color: #FFA500;
-      }
+
     .hero {
       display: flex;
       flex-direction: column;
@@ -251,7 +227,7 @@
       font-size: 0.8rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
     }
     @keyframes fadeInUp {
@@ -281,18 +257,7 @@
           });
         }
       });
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
-    }
-    const toggleBtn = document.getElementById('theme-toggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark-mode');
-        const isDark = document.documentElement.classList.contains('dark-mode');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    }
+    // Theme toggling removed
     });
   </script>
 </head>
@@ -305,7 +270,6 @@
     <a href="team.html">Meet the Team</a>
     <a href="achievements.html">Achievements</a>
   </nav>
-  <button id="theme-toggle">Toggle Theme</button>
 </header>
 
   <section class="hero">

--- a/privacy.html
+++ b/privacy.html
@@ -52,38 +52,17 @@
       margin-top: 2rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
       margin: 0 0.5rem;
     }
-    #theme-toggle {
-      background-color: #FFA500;
-      color: #000;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 6px;
-      font-weight: bold;
-      cursor: pointer;
-      margin-bottom: 1rem;
-    }
-    html.dark-mode body {
-      background-color: #121212;
-      color: #fff;
-    }
-    html.dark-mode .footer {
-      background-color: #333;
-      color: #fff;
-    }
-    html.dark-mode a {
-      color: #FFA500;
-    }
+    
   </style>
 </head>
 <body>
   <div class="back-button">
     <a href="index.html">← Back to Home</a>
   </div>
-  <button id="theme-toggle">Toggle Theme</button>
   <div class="back-button">
     <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon">Back to Home</a>
   </div>
@@ -101,21 +80,7 @@
   </div>
 
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'dark') {
-        document.documentElement.classList.add('dark-mode');
-      }
-
-      const toggleBtn = document.getElementById('theme-toggle');
-      if (toggleBtn) {
-        toggleBtn.addEventListener('click', () => {
-          document.documentElement.classList.toggle('dark-mode');
-          const isDark = document.documentElement.classList.contains('dark-mode');
-          localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        });
-      }
-    });
+    // Theme toggling removed
   </script>
 </body>
 </html>

--- a/team.html
+++ b/team.html
@@ -88,31 +88,6 @@
     .back-button a:active {
       transform: scale(0.95);
     }
-      #theme-toggle {
-        margin-left: 1rem;
-        background: none;
-        border: 2px solid currentColor;
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      html.dark-mode body {
-        background-color: #121212;
-        color: #fff;
-      }
-      html.dark-mode header {
-        background: linear-gradient(to right, #333, #555);
-      }
-      html.dark-mode .product-card {
-        background: #1e1e1e;
-      }
-      html.dark-mode .footer {
-        background-color: #333;
-        color: #fff;
-      }
-      html.dark-mode a {
-        color: #FFA500;
-      }
     .member {
       background-color: #111;
       padding: 2rem;
@@ -158,7 +133,7 @@
       font-size: 0.8rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
     }
     @media (min-width: 768px) {
@@ -185,18 +160,7 @@
           });
         }
       });
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
-    }
-    const toggleBtn = document.getElementById('theme-toggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark-mode');
-        const isDark = document.documentElement.classList.contains('dark-mode');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    }
+    // Theme toggling removed
     });
   </script>
 </head>
@@ -208,7 +172,6 @@
     <nav>
       <a href="index.html">Home</a>
     </nav>
-    <button id="theme-toggle">Toggle Theme</button>
   </header>
 
   <div class="team-container">

--- a/terms.html
+++ b/terms.html
@@ -52,34 +52,11 @@
       margin-top: 2rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
       margin: 0 0.5rem;
     }
-    #theme-toggle {
-      background-color: #FFA500;
-      color: #000;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 6px;
-      font-weight: bold;
-      cursor: pointer;
-      margin-bottom: 1rem;
-    }
-    html.dark-mode body {
-      background-color: #121212;
-      color: #fff;
-    }
-    html.dark-mode header {
-      background: linear-gradient(to right, #333, #555);
-    }
-    html.dark-mode .footer {
-      background-color: #333;
-      color: #fff;
-    }
-    html.dark-mode a {
-      color: #FFA500;
-    }
+
   </style>
 </head>
 <body>
@@ -87,7 +64,6 @@
     <a href="index.html">← Back to Home</a>
   </div>
   <h1>Terms &amp; Conditions</h1>
-  <button id="theme-toggle">Toggle Theme</button>
   <div class="back-button">
     <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon">Back to Home</a>
   </div>
@@ -105,41 +81,7 @@
   </div>
 
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'dark') {
-        document.documentElement.classList.add('dark-mode');
-      }
-
-      const toggleBtn = document.getElementById('theme-toggle');
-      if (toggleBtn) {
-        toggleBtn.addEventListener('click', () => {
-          document.documentElement.classList.toggle('dark-mode');
-          const isDark = document.documentElement.classList.contains('dark-mode');
-          localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        });
-      }
-    });
+    // Theme toggling removed
   </script>
-</body>
-</html>
-
-  </div>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
-    }
-    const toggleBtn = document.getElementById('theme-toggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark-mode');
-        const isDark = document.documentElement.classList.contains('dark-mode');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    }
-  });
-</script>
 </body>
 </html>

--- a/thankyou.html
+++ b/thankyou.html
@@ -37,38 +37,13 @@
       font-size: 0.8rem;
     }
     .footer a {
-      color: inherit;
+      color: #FFA500;
       text-decoration: none;
     }
-      #theme-toggle {
-        margin-left: 1rem;
-        background: none;
-        border: 2px solid currentColor;
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      html.dark-mode body {
-        background-color: #121212;
-        color: #fff;
-      }
-      html.dark-mode header {
-        background: linear-gradient(to right, #333, #555);
-      }
-      html.dark-mode .product-card {
-        background: #1e1e1e;
-      }
-      html.dark-mode .footer {
-        background-color: #333;
-        color: #fff;
-      }
-      html.dark-mode a {
-        color: #FFA500;
-      }
+
   </style>
 </head>
 <body>
-  <button id="theme-toggle">Toggle Theme</button>
   <h1>Thank You!</h1>
   <p>Your message has been sent successfully. We'll be in touch soon.</p>
   <a href="/">Back to Homepage</a>
@@ -78,20 +53,7 @@
       <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
-    }
-    const toggleBtn = document.getElementById('theme-toggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark-mode');
-        const isDark = document.documentElement.classList.contains('dark-mode');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    }
-  });
+  // Theme toggling removed
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- delete theme toggle button and related scripts
- strip dark-mode styles
- standardize footer link color across pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68578b1d8fec83218c1385b2eaad74e4