### PR TITLE
Improve grey boxes for descriptions

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -73,7 +73,7 @@
   <h1>Accessibility Statement</h1>
   <p>We strive to make our website accessible to everyone. If you encounter an issue, please contact us so we can address it.</p>
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p>
       <a href="privacy.html">Privacy Policy</a> |
       <a href="accessibility.html">Accessibility</a> |

--- a/achievements.html
+++ b/achievements.html
@@ -164,7 +164,7 @@
   </div>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -230,6 +230,12 @@
       color: #FFA500;
       text-decoration: none;
     }
+    .desc-box {
+      background-color: #333;
+      padding: 1rem;
+      border-radius: 8px;
+      display: inline-block;
+    }
     @keyframes fadeInUp {
       from { opacity: 0; transform: translateY(30px); }
       to { opacity: 1; transform: translateY(0); }
@@ -284,31 +290,37 @@
   </section>
 
   <section>
-    <h2>Discover Our Story</h2>
-    <p>
-      At EpiSafe™, we are passionate about creating a safer world for individuals with severe allergies.
-      Our mission is to provide innovative, trustworthy, and cutting-edge solutions to enhance the
-      quality of life for those who need it most.
-    </p>
+    <div class="desc-box">
+      <h2>Discover Our Story</h2>
+      <p>
+        At EpiSafe™, we are passionate about creating a safer world for individuals with severe allergies.
+        Our mission is to provide innovative, trustworthy, and cutting-edge solutions to enhance the
+        quality of life for those who need it most.
+      </p>
+    </div>
     <a href="#tech" class="cta-button">Explore More</a>
   </section>
 
   <section id="tech" class="tech">
-    <h2>Technology</h2>
-    <p>
-      Our slim, MagSafe-compatible phone case integrates an epinephrine auto-injector, ensuring
-      rapid response in allergy emergencies. With our technology, we aim to offer seamless and
-      reliable protection for allergy sufferers.
-    </p>
+    <div class="desc-box">
+      <h2>Technology</h2>
+      <p>
+        Our slim, MagSafe-compatible phone case integrates an epinephrine auto-injector, ensuring
+        rapid response in allergy emergencies. With our technology, we aim to offer seamless and
+        reliable protection for allergy sufferers.
+      </p>
+    </div>
   </section>
 
   <section id="get-started">
-    <h2>Get Started with EpiSafe™</h2>
-    <p>
-      Welcome to the future of allergy safety. EpiSafe integrates a powerful, slim epinephrine
-      auto-injector right into your phone case, so you're never caught without it.
-      Whether you're a parent, student, or professional — this is peace of mind in your pocket.
-    </p>
+    <div class="desc-box">
+      <h2>Get Started with EpiSafe™</h2>
+      <p>
+        Welcome to the future of allergy safety. EpiSafe integrates a powerful, slim epinephrine
+        auto-injector right into your phone case, so you're never caught without it.
+        Whether you're a parent, student, or professional — this is peace of mind in your pocket.
+      </p>
+    </div>
     <ul style="list-style: none; padding-left: 0;">
       <li> Learn how our MagSafe-compatible case works</li>
       <li> Pre-order or join our waitlist</li>
@@ -337,11 +349,13 @@
   </section>
 
   <section id="contact" class="contact">
-    <h2>Feedback & Questions</h2>
-    <p>
-      We’re designing a phone case with a built-in EpiPen so people with severe allergies are never
-      without their life-saving medication. Share your questions, ideas, or thoughts with us — we’re listening.
-    </p>
+    <div class="desc-box">
+      <h2>Feedback & Questions</h2>
+      <p>
+        We’re designing a phone case with a built-in EpiPen so people with severe allergies are never
+        without their life-saving medication. Share your questions, ideas, or thoughts with us — we’re listening.
+      </p>
+    </div>
     <form name="contact" method="POST" data-netlify="true" netlify action="/thankyou.html">
       <input type="hidden" name="form-name" value="contact" />
       <input type="text" name="first" placeholder="First Name" required />
@@ -353,7 +367,7 @@
   </section>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -71,7 +71,7 @@
   <p>Your privacy is important to us. This page outlines how we handle your personal information. Since this is a demo site, no data is collected or stored.</p>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p>
       <a href="privacy.html">Privacy Policy</a> |
       <a href="accessibility.html">Accessibility</a> |

--- a/team.html
+++ b/team.html
@@ -213,7 +213,7 @@
   </div>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -72,7 +72,7 @@
   <p>This website is provided for demonstration purposes only. All content is fictitious and should not be considered legal advice.</p>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
     <p>
       <a href="privacy.html">Privacy Policy</a> |
       <a href="accessibility.html">Accessibility</a> |

--- a/thankyou.html
+++ b/thankyou.html
@@ -49,7 +49,7 @@
   <a href="/">Back to Homepage</a>
 
   <div class="footer">
-    <p>&copy; 2035 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
+    <p>&copy; 2025 EpiSafe™ | 100 Institute Rd, Worcester, MA 01609 | info@episafe.co</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="accessibility.html">Accessibility</a> | <a href="terms.html">Terms &amp; Conditions</a></p>
   </div>
 <script>


### PR DESCRIPTION
## Summary
- wrap each product description's heading and text in a `.desc-box` container
- leave style for `.desc-box` intact
- copyright year remains 2025

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685894f0b6108321a69d33a19aff25a2