### PR TITLE
Dark theme styling for form fields

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -37,6 +37,22 @@
     h1 {
       margin-bottom: 1rem;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;

--- a/achievements.html
+++ b/achievements.html
@@ -101,6 +101,22 @@
     .achievement p {
       font-size: 0.95rem;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;

--- a/index.html
+++ b/index.html
@@ -199,12 +199,26 @@
     .cta-button:hover {
       background-color: #ffb733;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     form input, form textarea {
       width: 100%;
       margin-bottom: 1rem;
       padding: 0.75rem;
-      border: none;
-      border-radius: 6px;
     }
     form button {
       background-color: #FFA500;

--- a/privacy.html
+++ b/privacy.html
@@ -43,6 +43,22 @@
     h1 {
       margin-bottom: 1rem;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;

--- a/team.html
+++ b/team.html
@@ -125,6 +125,22 @@
     .member p {
       font-size: 0.95rem;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;

--- a/terms.html
+++ b/terms.html
@@ -43,6 +43,22 @@
     h1 {
       margin-bottom: 1rem;
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;

--- a/thankyou.html
+++ b/thankyou.html
@@ -29,6 +29,22 @@
     a:active {
       transform: scale(0.95);
     }
+    input, textarea {
+      background-color: #222;
+      color: #fff;
+      border: none;
+      outline: none;
+      border-radius: 6px;
+    }
+    input::placeholder,
+    textarea::placeholder {
+      color: #aaa;
+    }
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #FFA500;
+      box-shadow: 0 0 5px #FFA500;
+    }
     .footer {
       background-color: #000;
       color: #aaa;


### PR DESCRIPTION
## Summary
- apply consistent dark-themed `<input>` and `<textarea>` styles across pages
- ensure placeholders are light gray and focus state glows with accent color

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6858bdad2b508321b75371df6125ca7f