### PR TITLE
Add secret logo click Easter egg

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -47,6 +47,9 @@
       width: 80px;
       height: auto;
     }
+    #logo {
+      pointer-events: auto;
+    }
     nav a {
       color: inherit;
       text-decoration: none;
@@ -136,6 +139,21 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let count = 0;
+        let timer;
+        logo.addEventListener('click', () => {
+          count++;
+          clearTimeout(timer);
+          if (count >= 7) {
+            window.location.href = 'secret.html';
+          } else {
+            timer = setTimeout(() => { count = 0; }, 1500);
+          }
+        });
+      }
     // Theme toggling removed
     });
   </script>
@@ -143,7 +161,7 @@
 <body>
   <header>
     <div class="logo">
-      <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+      <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
     </div>
     <nav>
       <a href="index.html">Home</a>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,9 @@
       width: 80px;
       height: auto;
     }
+    #logo {
+      pointer-events: auto;
+    }
     header .logo span {
       font-size: 2rem;
       font-weight: 700;
@@ -263,6 +266,21 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let count = 0;
+        let timer;
+        logo.addEventListener('click', () => {
+          count++;
+          clearTimeout(timer);
+          if (count >= 7) {
+            window.location.href = 'secret.html';
+          } else {
+            timer = setTimeout(() => { count = 0; }, 1500);
+          }
+        });
+      }
     // Theme toggling removed
     });
   </script>
@@ -270,7 +288,7 @@
 <body>
 <header>
   <div class="logo">
-    <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+    <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
   </div>
   <nav>
     <a href="team.html">Meet the Team</a>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     }
     header .logo a {
       display: inline-block;
-      transition: transform 0.3s ease;
     }
     header .logo a:hover {
       transform: scale(1.05);

--- a/secret.html
+++ b/secret.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Secret | EpiSafe™</title>
+  <link rel="icon" href="images/episafeavicon.ico" type="image/x-icon" />
+  <style>
+    body {
+      background-color: #000;
+      color: #fff;
+      font-family: 'Inter', sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      text-align: center;
+    }
+    a {
+      color: #FFA500;
+      margin-top: 2rem;
+      text-decoration: none;
+      font-weight: bold;
+      transition: transform 0.3s ease;
+      display: inline-block;
+    }
+    a:active {
+      transform: scale(0.95);
+    }
+  </style>
+</head>
+<body>
+  <h1>You found the secret page!</h1>
+  <p>Congratulations on discovering this Easter egg.</p>
+  <a href="index.html">Back to Home</a>
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -57,6 +57,9 @@
       width: 80px;
       height: auto;
     }
+    #logo {
+      pointer-events: auto;
+    }
     nav a {
       color: inherit;
       text-decoration: none;
@@ -160,6 +163,21 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let count = 0;
+        let timer;
+        logo.addEventListener('click', () => {
+          count++;
+          clearTimeout(timer);
+          if (count >= 7) {
+            window.location.href = 'secret.html';
+          } else {
+            timer = setTimeout(() => { count = 0; }, 1500);
+          }
+        });
+      }
     // Theme toggling removed
     });
   </script>
@@ -167,7 +185,7 @@
 <body>
   <header>
     <div class="logo">
-      <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+      <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
     </div>
     <nav>
       <a href="index.html">Home</a>


### PR DESCRIPTION
## Summary
- add secret Easter egg page
- update logo markup to use id="logo"
- allow pointer events for the logo image
- count rapid logo clicks and redirect to the secret page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for bs4)*

------
https://chatgpt.com/codex/tasks/task_e_6858be5792fc832194c79aef949a7283