### PR TITLE
Fix Easter egg click behavior

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -47,6 +47,9 @@
       width: 80px;
       height: auto;
     }
+    #logo {
+      pointer-events: auto;
+    }
     nav a {
       color: inherit;
       text-decoration: none;
@@ -136,6 +139,29 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let hold;
+
+        const startPress = (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          clearTimeout(hold);
+          hold = setTimeout(() => {
+            window.location.href = 'secret.html';
+          }, 3000);
+        };
+
+        const cancelPress = (e) => {
+          e.stopPropagation();
+          clearTimeout(hold);
+        };
+
+        ['mousedown', 'touchstart'].forEach(evt => logo.addEventListener(evt, startPress));
+        ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(evt => logo.addEventListener(evt, cancelPress));
+        logo.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); });
+      }
     // Theme toggling removed
     });
   </script>
@@ -143,7 +169,7 @@
 <body>
   <header>
     <div class="logo">
-      <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+      <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
     </div>
     <nav>
       <a href="index.html">Home</a>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     }
     header .logo a {
       display: inline-block;
-      transition: transform 0.3s ease;
     }
     header .logo a:hover {
       transform: scale(1.05);
@@ -56,6 +55,9 @@
     header .logo img {
       width: 80px;
       height: auto;
+    }
+    #logo {
+      pointer-events: auto;
     }
     header .logo span {
       font-size: 2rem;
@@ -263,6 +265,29 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let hold;
+
+        const startPress = (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          clearTimeout(hold);
+          hold = setTimeout(() => {
+            window.location.href = 'secret.html';
+          }, 3000);
+        };
+
+        const cancelPress = (e) => {
+          e.stopPropagation();
+          clearTimeout(hold);
+        };
+
+        ['mousedown', 'touchstart'].forEach(evt => logo.addEventListener(evt, startPress));
+        ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(evt => logo.addEventListener(evt, cancelPress));
+        logo.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); });
+      }
     // Theme toggling removed
     });
   </script>
@@ -270,7 +295,7 @@
 <body>
 <header>
   <div class="logo">
-    <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+    <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
   </div>
   <nav>
     <a href="team.html">Meet the Team</a>

--- a/secret.html
+++ b/secret.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Secret | EpiSafe™</title>
+  <link rel="icon" href="images/episafeavicon.ico" type="image/x-icon" />
+  <style>
+    body {
+      background-color: #000;
+      color: #fff;
+      font-family: 'Inter', sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      text-align: center;
+    }
+    a {
+      color: #FFA500;
+      margin-top: 2rem;
+      text-decoration: none;
+      font-weight: bold;
+      transition: transform 0.3s ease;
+      display: inline-block;
+    }
+    a:active {
+      transform: scale(0.95);
+    }
+  </style>
+</head>
+<body>
+  <h1>You found the secret page!</h1>
+  <p>Congratulations on discovering this Easter egg.</p>
+  <a href="index.html">Back to Home</a>
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -57,6 +57,9 @@
       width: 80px;
       height: auto;
     }
+    #logo {
+      pointer-events: auto;
+    }
     nav a {
       color: inherit;
       text-decoration: none;
@@ -160,6 +163,29 @@
           });
         }
       });
+
+      const logo = document.getElementById('logo');
+      if (logo) {
+        let hold;
+
+        const startPress = (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          clearTimeout(hold);
+          hold = setTimeout(() => {
+            window.location.href = 'secret.html';
+          }, 3000);
+        };
+
+        const cancelPress = (e) => {
+          e.stopPropagation();
+          clearTimeout(hold);
+        };
+
+        ['mousedown', 'touchstart'].forEach(evt => logo.addEventListener(evt, startPress));
+        ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(evt => logo.addEventListener(evt, cancelPress));
+        logo.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); });
+      }
     // Theme toggling removed
     });
   </script>
@@ -167,7 +193,7 @@
 <body>
   <header>
     <div class="logo">
-      <a href="index.html"><img src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
+      <a href="index.html"><img id="logo" src="images/episafelogoog.png" alt="EpiSafe Icon" /></a>
     </div>
     <nav>
       <a href="index.html">Home</a>


### PR DESCRIPTION
## Summary
- stop logo click from bubbling to its parent link so the Easter egg triggers reliably
- change Easter egg requirement to 3-second press and hold to enter secret page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for bs4)*

------
https://chatgpt.com/codex/tasks/task_e_6858be5792fc832194c79aef949a7283