### PR TITLE
Serve webp images via picture tags

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -260,7 +260,12 @@
 <body>
   <header>
     <div class="logo">
-      <button id="logo"><img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" /></button>
+      <button id="logo">
+        <picture>
+          <source srcset="images/episafelogoog.webp" type="image/webp">
+          <img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" />
+        </picture>
+      </button>
     </div>
   </header>
   <nav id="menu" class="menu">
@@ -278,7 +283,10 @@
     <h1>Our Achievements</h1>
 
     <div class="achievement">
-      <img src="images/episafeawardetr2025.jpeg" alt="EpiSafe winning the ETR Goat Award 2025" loading="lazy">
+      <picture>
+        <source srcset="images/episafeawardetr2025.webp" type="image/webp">
+        <img src="images/episafeawardetr2025.jpeg" alt="EpiSafe winning the ETR Goat Award 2025" loading="lazy">
+      </picture>
       <h2>ETR 1100 D Term GOAT Award (2025)</h2>
       <p>Honoring the student whose work in ETR 1100 stood out above the rest — this award recognizes the most innovative, presentation-ready, and real-world-applicable concept of the term. From bold ideas to polished products, this GOAT proves vision and execution can change the game.</p>
     </div>

--- a/blog.html
+++ b/blog.html
@@ -189,7 +189,12 @@
   <body>
     <header>
       <div class="logo">
-        <button id="logo"><img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" /></button>
+        <button id="logo">
+          <picture>
+            <source srcset="images/episafelogoog.webp" type="image/webp">
+            <img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" />
+          </picture>
+        </button>
       </div>
     </header>
     <nav id="menu" class="menu">
@@ -203,7 +208,10 @@
     <h1>EpiSafe Blog</h1>
   <article>
     <h2>Coming Soon: Stories and Updates</h2>
-    <img src="images/episafeproductog.png" alt="EpiSafe phone case with built-in EpiPen auto-injector" loading="lazy" />
+    <picture>
+      <source srcset="images/episafeproductog.webp" type="image/webp">
+      <img src="images/episafeproductog.png" alt="EpiSafe phone case with built-in EpiPen auto-injector" loading="lazy" />
+    </picture>
     <p>Stay tuned for the latest news and insights from the EpiSafe team. Our blog will feature product updates, allergy safety tips, and behind-the-scenes stories.</p>
   </article>
 </body>

--- a/index.html
+++ b/index.html
@@ -381,7 +381,12 @@
 <body>
 <header>
   <div class="logo">
-    <button id="logo"><img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" /></button>
+    <button id="logo">
+      <picture>
+        <source srcset="images/episafelogoog.webp" type="image/webp">
+        <img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" />
+      </picture>
+    </button>
   </div>
 </header>
 <nav id="menu" class="menu">
@@ -399,7 +404,10 @@
       <a href="#get-started" class="cta-button">Get Started</a>
     </div>
     <div class="hero-img">
-      <img src="images/episafeproductog.png" alt="EpiSafe phone case with built-in EpiPen auto-injector" loading="lazy" />
+      <picture>
+        <source srcset="images/episafeproductog.webp" type="image/webp">
+        <img src="images/episafeproductog.png" alt="EpiSafe phone case with built-in EpiPen auto-injector" loading="lazy" />
+      </picture>
     </div>
   </section>
   <section>
@@ -441,17 +449,26 @@
 
   <section class="products">
     <div class="product-card">
-      <img src="images/episafeproductog.png" alt="MagSafe-compatible EpiSafe case" loading="lazy">
+      <picture>
+        <source srcset="images/episafeproductog.webp" type="image/webp">
+        <img src="images/episafeproductog.png" alt="MagSafe-compatible EpiSafe case" loading="lazy">
+      </picture>
       <h3>EpiSafe™ MagSafe Case</h3>
       <p>$75.00</p>
     </div>
     <div class="product-card">
-      <img src="images/episafeonlyautoinjector.png" alt="EpiSafe auto-injector pen" loading="lazy">
+      <picture>
+        <source srcset="images/episafeonlyautoinjector.webp" type="image/webp">
+        <img src="images/episafeonlyautoinjector.png" alt="EpiSafe auto-injector pen" loading="lazy">
+      </picture>
       <h3>EpiSafe™ Auto Injector Pen</h3>
       <p>$550.00</p>
     </div>
     <div class="product-card">
-      <img src="images/episafemount.png" alt="EpiSafe phone mount" loading="lazy">
+      <picture>
+        <source srcset="images/episafemount.webp" type="image/webp">
+        <img src="images/episafemount.png" alt="EpiSafe phone mount" loading="lazy">
+      </picture>
       <h3>EpiSafe™ Phone Case Mount</h3>
       <p>$20.00</p>
     </div>

--- a/team.html
+++ b/team.html
@@ -269,7 +269,12 @@
 <body>
   <header>
     <div class="logo">
-      <button id="logo"><img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" /></button>
+      <button id="logo">
+        <picture>
+          <source srcset="images/episafelogoog.webp" type="image/webp">
+          <img src="images/episafelogoog.png" alt="EpiSafe logo" loading="lazy" />
+        </picture>
+      </button>
     </div>
   </header>
   <nav id="menu" class="menu">
@@ -287,31 +292,46 @@
     <h1>Meet the Team</h1>
 
     <div class="member">
-      <img src="images/episafeaaryan.png" alt="Aaryan Panchal" loading="lazy">
+      <picture>
+        <source srcset="images/episafeaaryan.webp" type="image/webp">
+        <img src="images/episafeaaryan.png" alt="Aaryan Panchal" loading="lazy">
+      </picture>
       <h2><a href="https://www.linkedin.com/in/aaryan-panchal-13308222b" target="_blank">Aaryan Panchal</a></h2>
       <p>Leads the development of EpiSafe’s visual identity, product design language, and user-centered marketing. With a background in engineering, content, and consumer behavior, Aaryan ensures the product balances safety, lifestyle, and emotional resonance. He also built this website!</p>
     </div>
 
     <div class="member">
-      <img src="images/episafeesra.png" alt="Ezra Yohay" loading="lazy">
+      <picture>
+        <source srcset="images/episafeesra.webp" type="image/webp">
+        <img src="images/episafeesra.png" alt="Ezra Yohay" loading="lazy">
+      </picture>
       <h2><a href="https://www.linkedin.com/in/ezra-yohay-38a097265/" target="_blank">Ezra Yohay</a></h2>
       <p>Conceived EpiSafe after a severe allergic reaction. With a PhD in biophysics and industry experience at Genentech, Ezra brings expertise in microfabrication, leadership, and life-saving innovation to the product’s development and long-term vision.</p>
     </div>
 
     <div class="member">
-      <img src="images/episafeethan.png" alt="Ethan Takvorian" loading="lazy">
+      <picture>
+        <source srcset="images/episafeethan.webp" type="image/webp">
+        <img src="images/episafeethan.png" alt="Ethan Takvorian" loading="lazy">
+      </picture>
     <h2><a href="https://www.linkedin.com/in/ethan-takvorian-016611364?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">Ethan Takvorian</a></h2>
       <p>Combines biomedical engineering and computer science to develop EpiSafe’s core technology systems. He has streamlined operations, enhanced product reliability, and improved outcomes through thoughtful systems architecture and cross-functional collaboration.</p>
     </div>
 
     <div class="member">
-      <img src="images/episafejoshua.png" alt="Joshua Kashambala" loading="lazy">
+      <picture>
+        <source srcset="images/episafejoshua.webp" type="image/webp">
+        <img src="images/episafejoshua.png" alt="Joshua Kashambala" loading="lazy">
+      </picture>
       <h2><a href="https://www.linkedin.com/in/joshua-kashambala-23b423347/" target="_blank">Joshua Kashambala</a></h2>
       <p>Leverages his background in supply chain and operations from Purdue and Locus Robotics to lead logistics for EpiSafe. Manages product assembly, fulfillment, and shipping to bring EpiSafe from prototype to users efficiently and reliably.</p>
     </div>
 
     <div class="member">
-      <img src="images/episafekhusal.png" alt="Khushal Sharma" loading="lazy">
+      <picture>
+        <source srcset="images/episafekhusal.webp" type="image/webp">
+        <img src="images/episafekhusal.png" alt="Khushal Sharma" loading="lazy">
+      </picture>
       <h2><a href="https://www.linkedin.com/in/khushal-sharma-6a2981229/" target="_blank">Khushal Sharma</a></h2>
       <p>With a B.S. in Electrical and Computer Engineering and hands-on prototyping experience, Khushal bridges engineering and user needs. He leads iteration cycles and product testing to ensure each design balances safety, comfort, and usability.</p>
     </div>


### PR DESCRIPTION
## Summary
- Wrap all HTML images in `<picture>` elements with WebP `<source>` for faster modern loading and PNG/JPEG fallback.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4760a51c832187881e88de707f3c