### PR TITLE
Add Demo Day award and refresh landing page

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -134,6 +134,16 @@
 
     <div class="achievement">
       <picture>
+        <source srcset="images/episafe demoday pics-1-min.webp" type="image/webp">
+        <img src="images/episafe demoday pics-1-min.webp" alt="EpiSafe presenting at WPI Demo Day 2025" loading="lazy">
+      </picture>
+      <h2>WPI Demo Day 2025 – The Wire Group Special Award</h2>
+      <p>We took the stage at WPI Demo Day 2025 — the annual showcase where student founders present their ventures to campus, alumni, and industry leaders. The event packed the Innovation Studio with teams demoing prototypes, pitching to judges, and connecting with sponsors.</p>
+      <p>During our pitch, we were honored with the Wire Group Special Award, earning $500 in support and a dedicated pitch session with their team. Sharing EpiSafe with the Wire Group and the broader Demo Day audience was an incredible experience that validated our mission and sharpened our story.</p>
+    </div>
+
+    <div class="achievement">
+      <picture>
         <source srcset="images/episafeawardetr2025.webp" type="image/webp">
         <img src="images/episafeawardetr2025.webp" alt="EpiSafe winning the ETR Goat Award 2025" loading="lazy">
       </picture>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
   <link rel="preload" as="image" href="images/episafeproductog.webp" type="image/webp">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <style>
+    .hero-socials{margin-top:1rem;display:flex;gap:1rem;justify-content:center}.hero-socials a{color:#FFA500;font-size:1.8rem}
+    .hero-socials a:hover{color:#fff}@media (min-width:768px){.hero-socials{justify-content:flex-start}}
+  </style>
   <style>*{margin:0;padding:0;box-sizing:border-box}html{scroll-behavior:smooth}body{font-family:'Inter',sans-serif;background-color:#000;color:#fff;line-height:1.6;opacity:1;transition:opacity 0.5s ease}body.fade-out{opacity:0}body img{-webkit-user-drag:none;user-drag:none;pointer-events:none}header{--expanded-header-height:clamp(96px,12vw,128px);--collapsed-header-height:10px;display:flex;align-items:center;justify-content:center;height:var(--expanded-header-height);padding:0 2rem;background:linear-gradient(90deg,#ff8c00 0%,#ffad33 16%,#602a00 30%,#1a0900 40%,#000 50%,#1a0900 60%,#602a00 70%,#ffad33 84%,#ff8c00 100%);position:sticky;top:0;z-index:998;width:100%;overflow:hidden;transition:height .35s ease,box-shadow .35s ease,background .35s ease}header.header-collapsed{height:var(--collapsed-header-height);box-shadow:0 8px 24px rgba(0,0,0,.45);background:#ff8c00}header.header-collapsed .logo{opacity:0;pointer-events:none;transform:translateY(-24px)}header.header-collapsed .logo button{opacity:0}header .logo{display:flex;align-items:center;gap:1rem;transition:opacity .35s ease,transform .35s ease}header .logo button{background:none;border:none;padding:0;display:inline-block;cursor:pointer;transition:transform 0.3s ease,opacity 0.3s ease}header .logo button:hover{transform:scale(1.05)}header .logo button:active{transform:scale(0.95)}header .logo img{width:80px;height:auto;pointer-events:none}.menu{position:fixed;top:0;left:-260px;width:250px;height:100%;background-color:#000;display:flex;flex-direction:column;padding-top:4rem;transition:left 0.3s ease;z-index:1000}.menu a{color:#fff;text-decoration:none;padding:1rem 2rem;font-weight:600}.menu a:hover{color:#FFA500;background-color:#111}.menu.open{left:0}#overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);opacity:0;visibility:hidden;transition:opacity 0.3s ease;z-index:999}#overlay.show{opacity:1;visibility:visible}@media (max-width:600px){.menu{width:100%;left:-100%}}.hero{display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;padding:6rem 2rem}.hero-text{max-width:600px;animation:fadeInUp 1.2s ease-in-out}.hero-text h1{font-size:3.5rem;font-weight:700;margin-bottom:1rem}.hero-text p{font-size:1.25rem;margin-bottom:2rem}.hero-text .cta-button{background-color:#FFA500;color:black;padding:1rem 2rem;border:none;font-weight:bold;cursor:pointer;border-radius:8px;text-decoration:none;transition:transform 0.3s ease;display:inline-block}.hero-text .cta-button:active{transform:scale(0.95)}.hero-img{margin-top:2rem;animation:fadeIn 1.8s ease-in-out}.hero-img img{max-width:90%;border-radius:20px}@media (min-width:768px){.hero{flex-direction:row;text-align:left;gap:4rem}.hero-text{max-width:50%}.hero-img{max-width:50%;margin-top:0}.hero-img img{max-width:100%}}section{padding:4rem 2rem;max-width:900px;margin:0 auto;text-align:center}section h2{font-size:2rem;font-weight:600;margin-bottom:1rem}section p{font-size:1.1rem;margin-bottom:2rem}.products{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:clamp(1.5rem,3vw,2.5rem);max-width:1100px;margin:0 auto 4rem;align-items:stretch;justify-items:center}.product-card{--stack-gap:clamp(1rem,2vw,1.75rem);width:100%;max-width:360px;display:grid;grid-template-rows:1fr auto;gap:var(--stack-gap);transition:transform 0.3s ease-in-out}.product-card:hover{transform:translateY(-10px);--stack-gap:clamp(1.35rem,2.8vw,2.25rem)}.product-visual,.product-info{width:100%;background:#111;border-radius:16px;display:flex;align-items:center;justify-content:center;padding:calc(1.5rem + var(--stack-gap)/2)}.product-visual{background:#111;min-height:clamp(240px,32vw,320px)}.product-info{background:#181818;padding:calc(1.25rem + var(--stack-gap)/2);min-height:120px}.product-visual picture,.product-visual img{width:100%;display:block}.product-visual img{height:auto;border-radius:12px}.product-info h3{margin:0;font-size:1.2rem;font-weight:600;text-align:center}.product-card p{font-size:1rem;margin-top:0.5rem}.cta-button{background-color:#FFA500;color:#000;font-weight:bold;padding:1rem 2rem;border:none;border-radius:8px;cursor:pointer;text-decoration:none;transition:transform 0.3s ease;display:inline-block}.cta-button:active{transform:scale(0.95)}.cta-button:hover{background-color:#ffb733}input,textarea{background-color:#222;color:#fff;border:1px solid transparent;outline:none;border-radius:6px}input::placeholder,textarea::placeholder{color:#aaa}input:focus,textarea:focus{border-color:#FFA500;box-shadow:0 0 5px #FFA500}form input,form textarea{width:100%;margin-bottom:1rem;padding:0.75rem}form button{background-color:#FFA500;color:black;padding:0.75rem 1.5rem;border:none;font-weight:bold;cursor:pointer;border-radius:8px;transition:transform 0.3s ease}form button:active{transform:scale(0.95)}.footer{background-color:#000;color:#aaa;padding:2rem;text-align:center;font-size:0.8rem}.footer a{color:#FFA500;text-decoration:none}.socials{padding:2rem;text-align:center}.socials a{color:#FFA500;text-decoration:none;font-size:2rem;margin:0 0.5rem}.socials a:hover{color:#ffb733}.desc-box{background-color:#111;padding:1rem;border-radius:8px;display:inline-block}@keyframes fadeInUp{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:translateY(0)}}@keyframes fadeIn{from{opacity:0}to{opacity:1}}</style>
   <script>
     document.addEventListener('contextmenu', function (e) {
@@ -139,6 +143,12 @@
         <source srcset="images/episafeproductog.webp" type="image/webp">
         <img src="images/episafeproductog.webp" alt="EpiSafe phone case with built-in EpiPen auto-injector" />
       </picture>
+      <div class="hero-socials">
+        <a href="https://www.instagram.com/episafe.llc/" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+        <a href="https://www.linkedin.com/company/107233218/admin/dashboard/" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://x.com/episafe_?s=21" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+        <a href="https://www.facebook.com/share/1B1E8RLRg4/?mibextid=wwXIfr" target="_blank" aria-label="Facebook"><i class="fab fa-facebook"></i></a>
+      </div>
     </div>
   </section>
   <section>
@@ -176,42 +186,6 @@
     </ul>
     <br/>
     <a href="#contact" class="cta-button">Join the Waitlist</a>
-  </section>
-
-  <section class="products">
-    <div class="product-card">
-      <div class="product-visual">
-        <picture>
-          <source srcset="images/episafeproductog.webp" type="image/webp">
-          <img src="images/episafeproductog.webp" alt="MagSafe-compatible EpiSafe case" loading="lazy">
-        </picture>
-      </div>
-      <div class="product-info">
-        <h3>EpiSafe™ MagSafe Case</h3>
-      </div>
-    </div>
-    <div class="product-card">
-      <div class="product-visual">
-        <picture>
-          <source srcset="images/episafeonlyautoinjector.webp" type="image/webp">
-          <img src="images/episafeonlyautoinjector.webp" alt="EpiSafe auto-injector pen" loading="lazy">
-        </picture>
-      </div>
-      <div class="product-info">
-        <h3>EpiSafe™ Auto Injector Pen</h3>
-      </div>
-    </div>
-    <div class="product-card">
-      <div class="product-visual">
-        <picture>
-          <source srcset="images/episafemount.webp" type="image/webp">
-          <img src="images/episafemount.webp" alt="EpiSafe phone mount" loading="lazy">
-        </picture>
-      </div>
-      <div class="product-info">
-        <h3>EpiSafe™ Phone Case Mount</h3>
-      </div>
-    </div>
   </section>
 
   <section id="contact" class="contact">


### PR DESCRIPTION
## Summary
- add a WPI Demo Day 2025 achievement highlighting the Wire Group Special Award and event context
- surface social media links directly beneath the hero prototype image on the landing page
- remove the landing page product card section

## Testing
- not run (static content changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239364892083219d7f1a8a46bcb189)