### PR TITLE
Team & News pages, socials, 510(k) corrections, polish

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -743,7 +743,8 @@ body.is-menu-open { overflow: hidden; }
   color: var(--o);
   transform: translateY(-1px);
 }
-.socials__link svg { width: 18px; height: 18px; }
+.socials__link svg { width: 18px; height: 18px; display: block; }
+.socials__link[aria-label="LinkedIn"] svg { width: 22px; height: 22px; }
 .footer__col .socials { margin-top: 4px; }
 @media (max-width: 520px) {
   .socials__link { width: 36px; height: 36px; }


### PR DESCRIPTION
Same content as #41 but cut as a separate PR per request. Branch is at the same commit as `claude/design-implementation-S7LMI` — merging either one delivers the same site.

## What's here (on top of the original design rebuild)

**New pages**
- `team.html` — 4 detailed founder cards (photo, role, bio, "Working on" line), a "Coming soon" hiring grid with 4 ghost cards (Mechanical Engineer, Regulatory & Clinical Lead, iOS / Firmware Engineer, Operations & Supply Lead), and an "Apply to join" block.
- `news.html` — featured Demo Day 2025 post plus a 4-card grid (mechanism rev 3, app in TestFlight, ongoing lab, provisional patent).

**Nav & wiring**
- Team and News added to the desktop nav, mobile sheet menu, and footer Company column on every page.
- Nav logo tightened to `images/episafelogoog.webp`, gap reduced from 10px to 4px.

**Socials in every footer + news CTA**
- Instagram, LinkedIn, X, Facebook inline SVGs (no Font Awesome dep). IG uses `@episafe.co`; others pulled from the previous site's git history.
- LinkedIn glyph bumped to 22px (others 18px) since its path fills only ~73% of the viewBox vs ~90% for the rest — without this it read visibly smaller.

**Regulatory pathway → 510(k)**
- Every reference updated from FDA 505(b)(2) to 510(k): traction metric, Q-Sub milestone, human-factors milestone (renamed from "Clinical bridging studies"), launch milestone, use-of-funds row, product specs table, team Working-on line, news lab post.
- Drug-pathway terms replaced with device equivalents: "bioequivalence to Reference Listed Drug" → "substantial equivalence to predicate auto-injector"; "NDA filed" → "510(k) submission filed"; "approval" → "clearance"; etc.

**Visual polish**
- Moved `.cta-block` from inline (index only) to shared `styles.css` so all 6 pages get rounded liquid-glass corners on their CTAs.
- Tightened vertical rhythm: section padding, section-head margin, hero padding-top, footer padding, story question/chapter sections — all pulled in to remove unnecessary air.
- Mobile horizontal scroll: `overflow-x: clip` on html and body, app-screens triptych reworked at <520px to fit narrow viewports.
- "EpiSafe Inc." → "EpiSafe LLC" in footers and legal pages.
- Team headline rewritten ("obsessed with the 56%" instead of "who needed it themselves").
- Product page FORM callout connector restored.

## Tests
`pytest tests/` — 9/9 passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RLyCqjW1iu9aYVBzVCs9G)_