### PR TITLE
Batch 1 — Credibility & correctness: sourced stats, dose-equivalence, advisors

### DIFF
--- a/story.html
+++ b/story.html
@@ -391,7 +391,7 @@
       <span class="chapter__num">Chapter 02 &middot; The approach</span>
       <h2 class="chapter__title">Not a smaller EpiPen.<br><span class="italic-serif">A rebuilt one.</span></h2>
       <div class="chapter__body">
-        <p>Every part inside an auto-injector was designed around a six-inch tube. We didn't try to shrink it , we redrew the geometry, simulated the fluid dynamics, and validated dose equivalence against a standard intramuscular injection.</p>
+        <p>Every part inside an auto-injector was designed around a six-inch tube. We didn't try to shrink it , we redrew the geometry, simulated the fluid dynamics, and engineered for a dose equivalent to a standard intramuscular injection , now being validated in bench testing.</p>
         <p>Then we did the harder part: we put it in a phone case. The device people carry 100 times a day now carries the device that saves their life.</p>
       </div>
     </div>

--- a/story.html
+++ b/story.html
@@ -373,8 +373,9 @@
       <h2 class="chapter__title">The treatment exists.<br>The <span class="italic-serif" style="font-family: &quot;Paul Grotesk&quot;">device fails it.</span></h2>
       <div class="chapter__body">
         <p>The EpiPen has barely changed since 1987. Six inches long. Awkward to pocket. Designed to live in a backpack that you don't always grab.</p>
-        <p>So the data ends up where you'd expect: 56% of people prescribed an EpiPen don't carry one. 225 preventable deaths every year in the U.S. alone. A $1.2 billion annual cost from anaphylaxis-related care , most of it because someone, somewhere, left their device on a kitchen counter.</p>
+        <p>So the data ends up where you'd expect: 56% of people prescribed an EpiPen don't carry one. 225 deaths a year from anaphylaxis in the U.S. $33 billion a year in direct medical costs from severe allergic reactions. And too often, the difference between a scare and a tragedy is simply whether the device was on you , or left on a kitchen counter.</p>
         <p>Anaphylaxis can kill in minutes. The device meant to stop it shouldn't have a "but I left it at home" failure mode.</p>
+        <p style="font-size:12px; color: var(--fg-mute); margin-top: 6px;">Sources: <a href="https://allergyasthmanetwork.org/anaphylaxis/anaphylaxis-statistics/" target="_blank" rel="noopener" style="color: var(--fg-soft)">Allergy &amp; Asthma Network</a> (2026); ACAAI.</p>
       </div>
     </div>
     <div class="chapter__media glass reveal" style="--d: 150ms">

--- a/team.html
+++ b/team.html
@@ -147,6 +147,52 @@
     margin-bottom: 14px;
   }
 
+  /* Advisors */
+  .adv-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+  }
+  .adv-card {
+    padding: 28px 26px;
+    border-radius: var(--r);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 180px;
+  }
+  .adv-card__name {
+    font-size: 20px;
+    font-weight: 500;
+    letter-spacing: var(--tracking-tight);
+    color: var(--fg);
+    transition: color .2s;
+  }
+  a.adv-card__name:hover { color: var(--o); }
+  .adv-card__role {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--o);
+  }
+  .adv-card__bio {
+    color: var(--fg-soft);
+    font-size: 14px;
+    line-height: 1.55;
+    margin-top: auto;
+  }
+  .adv-card__link {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: var(--tracking-wide);
+    color: var(--fg-mute);
+    margin-top: 14px;
+    transition: color .2s;
+  }
+  .adv-card__link:hover { color: var(--o); }
+  @media (max-width: 900px) { .adv-grid { grid-template-columns: 1fr; } }
+
   /* Apply to join */
   .apply {
     padding: clamp(48px, 7vw, 84px);
@@ -299,8 +345,40 @@
   </div>
 </section>
 
+<!-- ADVISORS -->
+<section class="section section--tight wrap" data-screen-label="03 Advisors">
+  <div class="section-head reveal" style="margin-bottom: 40px">
+    <span class="eyebrow"><span class="eyebrow__dot"></span> Advisors</span>
+    <h2 class="h-section" style="font-size: clamp(32px, 4vw, 52px)">
+      Guided by people who've<br><span class="italic-serif">built and shipped before.</span>
+    </h2>
+    <p class="lede">Business, regulatory, and venture advisors who keep us honest on the path from prototype to FDA submission.</p>
+  </div>
+
+  <div class="adv-grid">
+    <article class="adv-card glass reveal">
+      <a class="adv-card__name" href="https://www.linkedin.com/in/evanlcox/" target="_blank" rel="noopener">Evan Cox</a>
+      <span class="adv-card__role">Business &amp; strategy</span>
+      <p class="adv-card__bio">Advises on company strategy, fundraising, and go-to-market as EpiSafe moves from concept to a fundable medical-device company.</p>
+      <a class="adv-card__link" href="https://www.linkedin.com/in/evanlcox/" target="_blank" rel="noopener">LinkedIn →</a>
+    </article>
+    <article class="adv-card glass reveal" style="--d: 80ms">
+      <a class="adv-card__name" href="https://www.linkedin.com/in/gumbrell/" target="_blank" rel="noopener">George Gumbrell</a>
+      <span class="adv-card__role">Regulatory · FDA</span>
+      <p class="adv-card__bio">Brings FDA and regulatory experience to the combination-product strategy , predicate selection and the road to a 510(k) pre-submission.</p>
+      <a class="adv-card__link" href="https://www.linkedin.com/in/gumbrell/" target="_blank" rel="noopener">LinkedIn →</a>
+    </article>
+    <article class="adv-card glass reveal" style="--d: 160ms">
+      <a class="adv-card__name" href="https://www.linkedin.com/in/ardianpreci/" target="_blank" rel="noopener">Ardian Preci</a>
+      <span class="adv-card__role">WPI i3 Lab</span>
+      <p class="adv-card__bio">Our WPI i3 Lab advisor , mentoring the team through the accelerator and opening doors across the medical-device and investor network.</p>
+      <a class="adv-card__link" href="https://www.linkedin.com/in/ardianpreci/" target="_blank" rel="noopener">LinkedIn →</a>
+    </article>
+  </div>
+</section>
+
 <!-- COMING SOON ROLES -->
-<section class="section section--tight wrap" data-screen-label="03 Coming Soon">
+<section class="section section--tight wrap" data-screen-label="04 Coming Soon">
   <div class="section-head reveal" style="margin-bottom: 40px">
     <span class="eyebrow"><span class="eyebrow__dot"></span> Coming soon</span>
     <h2 class="h-section" style="font-size: clamp(32px, 4vw, 52px)">

--- a/team.html
+++ b/team.html
@@ -237,7 +237,7 @@
       <span class="italic-serif">One mission.</span>
     </h1>
     <p class="lede tm-hero__lede">
-      We sit across operations, science, design, and revenue. Each of us owns one slice of the path from prototype to pharmacy shelf.
+      We sit across strategy, operations, design, and research. Each of us owns one slice of the path from prototype to pharmacy shelf.
     </p>
   </div>
 </header>


### PR DESCRIPTION
Batch 1 of the post-discovery site improvements — credibility & correctness. Independent of #49 (touches different lines, so no conflict).

## Stats: sourced & corrected (story.html)
- **"225 deaths a year from anaphylaxis"** — confirmed against the [Allergy & Asthma Network](https://allergyasthmanetwork.org/anaphylaxis/anaphylaxis-statistics/) (dropped the unsupported "preventable" qualifier).
- **Cost figure corrected:** the old "$1.2 billion" was unsourced and wrong — the AAN figure is **$33 billion/yr in direct medical costs** (2024, CPI-adjusted). Updated (and it's a stronger number).
- Removed the unsupported causal claim ("most of it because someone left their device on a kitchen counter") and reframed it as narrative.
- Added a **Sources** line citing Allergy & Asthma Network (2026) + ACAAI.

## Dose-equivalence honesty (story.html)
- "validated dose equivalence" overstated completed work and contradicted the traction roadmap (bench testing is in progress). Reworded to "engineered for a dose equivalent … now being validated in bench testing."

## CRO role (team.html)
- Team hero said the team spans "revenue," but the CRO is **Chief Research Officer** with a research bio. Changed "revenue" → "research."

## Advisors section (team.html)
- New **Advisors** section with three named advisors, each linked to LinkedIn:
  - **Evan Cox** — Business & strategy
  - **George Gumbrell** — Regulatory · FDA
  - **Ardian Preci** — WPI i3 Lab advisor
- Closes the "no named advisors" credibility gap flagged in the review.

⚠️ Please verify: **George Gumbrell's** exact name spelling and each advisor's preferred title (LinkedIn blocks automated lookups, so titles are from our discovery notes — easy to refine).

All 9 HTML tests pass.

https://claude.ai/code/session_013JjDUDe8WPXRyPLpN6haz6